### PR TITLE
Convert Angular CLI app into static personal landing page and refactor UI/components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,48 +1,11 @@
 {
   "name": "web-cli",
-  "version": "0.0.0",
-  "scripts": {
-    "ng": "ng",
-    "start": "ng serve",
-    "build": "ng build",
-    "test": "ng test",
-    "lint": "ng lint",
-    "e2e": "ng e2e"
-  },
+  "version": "2.0.0",
   "private": true,
-  "dependencies": {
-    "@angular/animations": "^6.0.3",
-    "@angular/common": "^6.0.3",
-    "@angular/compiler": "^6.0.3",
-    "@angular/core": "^6.0.3",
-    "@angular/forms": "^6.0.3",
-    "@angular/http": "^6.0.3",
-    "@angular/platform-browser": "^6.0.3",
-    "@angular/platform-browser-dynamic": "^6.0.3",
-    "@angular/router": "^6.0.3",
-    "core-js": "^2.5.4",
-    "rxjs": "^6.0.0",
-    "zone.js": "^0.8.26"
-  },
-  "devDependencies": {
-    "@angular/compiler-cli": "^6.0.3",
-    "@angular-devkit/build-angular": "~0.6.8",
-    "typescript": "~2.7.2",
-    "@angular/cli": "~6.0.8",
-    "@angular/language-service": "^6.0.3",
-    "@types/jasmine": "~2.8.6",
-    "@types/jasminewd2": "~2.0.3",
-    "@types/node": "~8.9.4",
-    "codelyzer": "~4.2.1",
-    "jasmine-core": "~2.99.1",
-    "jasmine-spec-reporter": "~4.2.1",
-    "karma": "~1.7.1",
-    "karma-chrome-launcher": "~2.2.0",
-    "karma-coverage-istanbul-reporter": "~2.0.0",
-    "karma-jasmine": "~1.1.1",
-    "karma-jasmine-html-reporter": "^0.2.2",
-    "protractor": "~5.3.0",
-    "ts-node": "~5.0.1",
-    "tslint": "~5.9.1"
+  "description": "Personal landing page",
+  "scripts": {
+    "start": "python3 -m http.server 4173 --directory src",
+    "build": "mkdir -p dist && cp -r src/* dist/",
+    "test": "node -p \"'No automated tests configured for static site.'\""
   }
 }

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,79 +1,199 @@
-/* div {
-  border: solid 1px red;
-} */
-
-.background{
-  background-image: url("../assets/computer-screen-2.png");
-  background-repeat:no-repeat;
-  background-position: center center;
-  background-size: 90rem;
-  height: 75rem;
-}
-.projects{
-  position: relative;
-  top: -11rem;
-  left: 58rem;
-  height: 22rem;
-  width: 32rem;
-}
-.projects-prompt{
-  height: 22rem;
-  width: 31rem;
+:host {
+  display: block;
+  min-height: 100vh;
+  color: #101114;
 }
 
-.projects-button{
-  position: relative;
-  top: -3.25rem;
-  left: 22.8rem;
+.shell {
+  min-height: 100vh;
+  padding: 1.25rem;
+  background:
+    radial-gradient(1200px 500px at 15% -10%, #dbe8ff 0%, #f6f8fb00 60%),
+    radial-gradient(900px 400px at 100% 0%, #f2f4fa 0%, #f6f8fb00 65%),
+    linear-gradient(180deg, #f6f8fb 0%, #eef2f8 100%);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
-.projects-button-img{
-  height: 2rem;
-  width: 7rem;
+.topbar {
+  max-width: 1060px;
+  margin: 0 auto 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.7rem 0.2rem;
 }
 
-.container {
-  position: relative;
-  top: 12rem;
-  left: 58rem;
-  width: 33.5rem;
-  height: 23rem;
-  font-family: 'Roboto',  sans-serif;
-  font-size: 1rem;
-  overflow-x: auto;
+.logo {
+  font-weight: 700;
+  letter-spacing: 0.01em;
 }
 
-.text-input {
-  height: 1rem;
-  background: transparent;
-  border: white;
-  color: green;
-  font-family: 'Roboto', sans-serif;
-  font-size: 1rem;
-  overflow: hidden;
-  resize: none;
-  width: calc(100% - 10rem);
-  vertical-align: text-top
+nav {
+  display: flex;
+  gap: 1rem;
 }
 
-*:focus {
-  outline: none;
+nav a {
+  color: #4f566b;
+  text-decoration: none;
+  font-size: 0.92rem;
+  font-weight: 500;
 }
 
-@media only screen and (max-width: 1440px) {
-  .container {
-    left: 24rem;
+main {
+  max-width: 1060px;
+  margin: 0 auto;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.glass {
+  background: #ffffffc2;
+  border: 1px solid #ffffff;
+  border-radius: 22px;
+  box-shadow: 0 10px 35px #6f85ab21;
+  backdrop-filter: blur(14px);
+}
+
+.hero,
+.about,
+.contact {
+  padding: 2rem;
+}
+
+.kicker {
+  margin: 0;
+  color: #6a7186;
+  font-size: 0.84rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0.4rem 0;
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 1.08;
+  letter-spacing: -0.03em;
+}
+
+.role {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #31374a;
+  font-weight: 600;
+}
+
+.location {
+  margin-top: 0.8rem;
+  color: #5d657d;
+  max-width: 62ch;
+  line-height: 1.6;
+}
+
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-top: 1.3rem;
+}
+
+.btn {
+  border: 1px solid #d5daea;
+  color: #151924;
+  text-decoration: none;
+  border-radius: 999px;
+  padding: 0.57rem 1rem;
+  font-size: 0.92rem;
+  font-weight: 600;
+  background: #fff;
+}
+
+.btn-primary {
+  border: 1px solid #1f232f;
+  background: #1f232f;
+  color: #fff;
+}
+
+h2 {
+  margin-top: 0;
+  margin-bottom: 0.6rem;
+  font-size: 1.35rem;
+  letter-spacing: -0.01em;
+}
+
+ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: #434a5d;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.work {
+  padding: 0.2rem;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.card {
+  padding: 1.25rem;
+}
+
+.tag {
+  display: inline-block;
+  font-size: 0.75rem;
+  color: #6a7186;
+  background: #eef2f8;
+  border-radius: 999px;
+  padding: 0.18rem 0.52rem;
+  margin-bottom: 0.6rem;
+}
+
+h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.05rem;
+  letter-spacing: -0.01em;
+}
+
+.card p,
+.contact p,
+.note {
+  margin: 0;
+  color: #515973;
+  line-height: 1.52;
+}
+
+.contact {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.note {
+  font-size: 0.9rem;
+}
+
+@media (max-width: 920px) {
+  .cards {
+    grid-template-columns: 1fr;
   }
 }
 
-@media only screen and (max-width: 1024px) {
-  .container {
-    left: 12rem;
+@media (max-width: 640px) {
+  .shell {
+    padding: 0.8rem;
   }
-}
 
-@media only screen and (max-width: 768px) {
-  .container {
-    left: 2rem;
+  .hero,
+  .about,
+  .contact {
+    padding: 1.2rem;
+  }
+
+  nav {
+    gap: 0.7rem;
   }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,21 +1,49 @@
-<!--The content below is only a placeholder and can be replaced.-->
+<div class="shell">
+  <header class="topbar">
+    <div class="logo">Theodor</div>
+    <nav>
+      <a href="#about">About</a>
+      <a href="#work">Work</a>
+      <a href="#contact">Contact</a>
+    </nav>
+  </header>
 
-<div class="background">
-  <div class="container">
-    <span *ngFor="let message of messages">
-      <div [innerHTML]="message.value"></div>
-      <br/>
-      <br/>
-    </span>
-    <span>C:\Users\root>
-      <textarea autofocus class="text-input" #msgInput (keydown.enter)="appendMessage('C:\\Users\\root> '+msgInput.value);false"></textarea>
-    </span>
-    
-  </div>
-  <div class="projects" [hidden]="!projectsShow">
-      <img class="projects-prompt" src="{{popUpImgSrc}}?d={{clock_tick}}" />
-      <a class="projects-button" (click)="nextImg()" >
-        <img class="projects-button-img" src="../assets/button.PNG" />
-      </a>
-    </div>
+  <main>
+    <section class="hero glass">
+      <p class="kicker">Personal Website</p>
+      <h1>{{ name }}</h1>
+      <p class="role">{{ role }}</p>
+      <p class="location">{{ location }}</p>
+      <div class="cta-row">
+        <a class="btn btn-primary" [href]="links.email">Get in touch</a>
+        <a class="btn" [href]="links.linkedin" target="_blank" rel="noopener">LinkedIn</a>
+        <a class="btn" [href]="links.github" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </section>
+
+    <section class="about glass" id="about">
+      <h2>What I focus on</h2>
+      <ul>
+        <li *ngFor="let item of highlights">{{ item }}</li>
+      </ul>
+    </section>
+
+    <section class="work" id="work">
+      <h2>Selected Areas</h2>
+      <div class="cards">
+        <article class="card glass" *ngFor="let project of projects">
+          <span class="tag">{{ project.tag }}</span>
+          <h3>{{ project.name }}</h3>
+          <p>{{ project.summary }}</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="contact glass" id="contact">
+      <h2>Elsewhere</h2>
+      <p>Read long-form thoughts on engineering and product:</p>
+      <a class="btn" [href]="links.blog" target="_blank" rel="noopener">Blog</a>
+      <p class="note">Share your latest CV updates and I’ll fold in a full timeline section next.</p>
+    </section>
+  </main>
 </div>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,27 +1,29 @@
-import { TestBed, async } from '@angular/core/testing';
+import { async, TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
+
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [
-        AppComponent
-      ],
+      declarations: [AppComponent]
     }).compileComponents();
   }));
+
   it('should create the app', async(() => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
     expect(app).toBeTruthy();
   }));
-  it(`should have as title 'app'`, async(() => {
+
+  it('should expose profile name', async(() => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
-    expect(app.title).toEqual('app');
+    expect(app.name).toEqual('Theodor Chichirita');
   }));
-  it('should render title in a h1 tag', async(() => {
+
+  it('should render hero headline', async(() => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('h1').textContent).toContain('Welcome to web-cli!');
+    expect(compiled.querySelector('h1').textContent).toContain('Theodor Chichirita');
   }));
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,122 +1,50 @@
-import { Component, ViewChild, ElementRef, OnInit, AfterViewChecked, QueryList, AfterViewInit } from '@angular/core';
+import { Component } from '@angular/core';
+
+interface Project {
+  name: string;
+  summary: string;
+  tag: string;
+}
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
+export class AppComponent {
+  readonly name = 'Theodor Chichirita';
+  readonly role = 'Senior Software Engineer';
+  readonly location = 'Building cloud-first products with a focus on scale, quality, and craft.';
 
-export class AppComponent implements OnInit, AfterViewChecked {
-  @ViewChild('msgInput') private msgInput: ElementRef;
-  @ViewChild('container') private tex: ElementRef;
-
-  messages = Array<{ id: number; value: string }>();
-  projectsShow = false;
-  popUpImgSrc:string;
-  popUpImgN;
-  clock_tick;
-  popUpImgSrcArray = [
-    "../assets/cobol.png",
-    "../assets/fiera.png",
-    "../assets/cox.png",
-    "../assets/fortress.png",
-    "../assets/newday.png",
-    "../assets/amido.png",
+  readonly highlights: string[] = [
+    'End-to-end product engineering',
+    'Cloud architecture and modernization',
+    'High-transaction system performance',
+    'DevSecOps and platform reliability'
   ];
-  ngOnInit() {
-    this.msgInput.nativeElement.focus();
-    this.messages.push({
-      id: 0,
-      value: 'Theodor Chichirita [Version 23.8.16]<br/>(c) 2018 Chichirita Corporations.All rights reserved.'
-    });
-    this.clock_tick = Date.now();
-    this.popUpImgSrc =  "../assets/cobol.png";
-    this.popUpImgN = 0;
-  }
-  ngAfterViewChecked() {
-    this.msgInput.nativeElement.scrollIntoView();
-  }
-  appendMessage(value: string) {
-    const input = 'C:\\Users\\root> ';
-    this.messages.push({ id: this.messages.length, value: value });
-    // alert(value.toLowerCase());
-    // alert(input.toLowerCase() + 'hello');
-    switch (true) {
-      // tslint:disable-next-line:max-line-length
-      case ( value.toLowerCase() === input.toLowerCase() + 'hello' || value.toLowerCase() === input.toLowerCase() + 'help' || value.toLowerCase() === input.toLowerCase() + 'start' || value.toLowerCase() === input.toLowerCase() + 'hi' || value.toLowerCase() === input.toLowerCase() + '.' ) : {
-        this.messages.push({ id: this.messages.length, value:
-            // tslint:disable-next-line:max-line-length
-            'Hi, my Name is Theodor Chichirita, and I\'m a software engineer ☁ <br/><u>A</u>bout<br/><u>P</u>rojects<br/><u>M</u>ail<br/><u>L</u>inkedin<br/><u>G</u>ithub<br/><u>B</u>log' });
-        break;
-      }
-      case ( value.toLowerCase() === input.toLowerCase() + 'linkedin' || value.toLowerCase() === input.toLowerCase() + 'l' ) : {
-        this.messages.push({
-          id: this.messages.length,
-          value:
-            '<a href="https://www.linkedin.com/in/theodor-chichirita-78770b140/">Theodor Chichirita</a>'
-        });
-        break;
-      }
-      case ( value.toLowerCase() === input.toLowerCase() + 'github' || value.toLowerCase() === input.toLowerCase() + 'g' ) : {
-        this.messages.push({
-          id: this.messages.length,
-          value: '<a href="https://github.com/estatheo">Github</a>'
-        });
-        break;
-      }
-      case ( value.toLowerCase() === input.toLowerCase() + 'blog' || value.toLowerCase() === input.toLowerCase() + 'b' ) : {
-        this.messages.push({
-          id: this.messages.length,
-          value:
-            '<a href="https://medium.com/@theodor.chichirita">Medium</a>'
-        });
-        break;
-      }
-      case (value.toLowerCase() === input.toLowerCase() + 'mail' || value.toLowerCase() === input.toLowerCase() + 'm'): {
-        this.messages.push({
-          id: this.messages.length,
-          value:
-            '<a href="mailto:theodor.chichirita@gmail.com?Subject=Hello!">theodor.chichirita@gmail.com</a>'
-        });
-        break;
-      }
-      case ( value.toLowerCase() === input.toLowerCase() + 'about' || value.toLowerCase() === input.toLowerCase() + 'a' ) : {
-        this.messages.push({ id: this.messages.length, value:
-            // tslint:disable-next-line:max-line-length
-            'Experienced Full Stack Developer with a demonstrated history of working in the software industry.<br/>Skilled in Product Development, Solution architect, Cloud and High transaction systems, User Experience.<br/>DevOps, DevSec and Performance Optimization. Strong engineering, professional mindset with lots of creativity and up to date with the latest technologies.' });
-        break;
-      }
-      case ( value.toLowerCase() === input.toLowerCase() + 'projects' || value.toLowerCase() === input.toLowerCase() + 'p' ) : {
-        // this.messages.push({
-        //   id: this.messages.length,
-        //   value: 'Work in progress (this UI (; )'
-        // });
-        this.popUpImgSrc = this.popUpImgSrcArray[0];
-        this.clock_tick = Date.now();
-        this.projectsShow = true;
-        break;
-      }
-      case ( value.toLowerCase() === input.toLowerCase() + 'clear' || value.toLowerCase() === input.toLowerCase() + 'cls' ) : {
-        this.messages = Array<{ id: number; value: string }>();
-        this.messages.push({
-          id: 0,
-          value: 'Theodor Chichirita [Version 23.8.16]<br/>(c) 2018 Chichirita Corporations.All rights reserved.'
-        });
-      }
-    }
-    this.msgInput.nativeElement.value = '';
-  }
 
-  nextImg(){
-    if(this.popUpImgN > 4){
-      this.popUpImgN = 0;
-      this.popUpImgSrc = this.popUpImgSrcArray[0];
-      this.projectsShow = false;
+  readonly projects: Project[] = [
+    {
+      name: 'Enterprise Product Platforms',
+      summary: 'Shipped mission-critical product experiences across cross-functional teams.',
+      tag: 'Product'
+    },
+    {
+      name: 'Cloud-Native Architecture',
+      summary: 'Designed scalable, secure, and maintainable systems for long-term growth.',
+      tag: 'Cloud'
+    },
+    {
+      name: 'Performance Engineering',
+      summary: 'Improved throughput and UX quality in heavy-traffic environments.',
+      tag: 'Performance'
     }
-    else {
-      this.popUpImgN++;
-      this.popUpImgSrc = this.popUpImgSrcArray[this.popUpImgN];
-    }
-    this.clock_tick = Date.now();
-  }
+  ];
+
+  readonly links = {
+    linkedin: 'https://www.linkedin.com/in/theodor-chichirita-78770b140/',
+    github: 'https://github.com/estatheo',
+    blog: 'https://medium.com/@theodor.chichirita',
+    email: 'mailto:theodor.chichirita@gmail.com?subject=Hello%20Theodor'
+  };
 }

--- a/src/index.html
+++ b/src/index.html
@@ -1,18 +1,88 @@
 <!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Theodor Chichirita</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Personal landing page for Theodor Chichirita — software engineer focused on cloud architecture, product engineering, and high-performance systems."
+    />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="shell">
+      <header class="topbar">
+        <a class="logo" href="#home">Theodor</a>
+        <nav>
+          <a href="#about">About</a>
+          <a href="#work">Work</a>
+          <a href="#contact">Contact</a>
+        </nav>
+      </header>
 
-<head>
-  <meta charset="utf-8">
-  <title>Theodor Chichirita</title>
-  <base href="/">
+      <main id="home">
+        <section class="hero glass">
+          <p class="kicker">Personal Website</p>
+          <h1>Theodor Chichirita</h1>
+          <p class="role">Senior Software Engineer</p>
+          <p class="location">
+            I design and ship cloud-first software products with a strong focus on reliability,
+            performance, and delightful user experience.
+          </p>
 
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
-</head>
+          <div class="cta-row">
+            <a class="btn btn-primary" href="mailto:theodor.chichirita@gmail.com?subject=Hello%20Theodor">Get in touch</a>
+            <a class="btn" href="https://www.linkedin.com/in/theodor-chichirita-78770b140/" target="_blank" rel="noopener">LinkedIn</a>
+            <a class="btn" href="https://github.com/estatheo" target="_blank" rel="noopener">GitHub</a>
+          </div>
+        </section>
 
-<body>
-  <app-root></app-root>
-</body>
+        <section class="about glass" id="about">
+          <h2>What I focus on</h2>
+          <ul>
+            <li>End-to-end product engineering.</li>
+            <li>Cloud architecture and modernization.</li>
+            <li>High-transaction system performance optimization.</li>
+            <li>DevSecOps and platform reliability practices.</li>
+          </ul>
+        </section>
 
+        <section class="work" id="work">
+          <h2>Selected Areas</h2>
+          <div class="cards">
+            <article class="card glass">
+              <span class="tag">Product</span>
+              <h3>Enterprise Product Platforms</h3>
+              <p>Delivered mission-critical capabilities across cross-functional engineering teams.</p>
+            </article>
+            <article class="card glass">
+              <span class="tag">Cloud</span>
+              <h3>Cloud-Native Architecture</h3>
+              <p>Designed scalable and secure systems built for long-term maintainability.</p>
+            </article>
+            <article class="card glass">
+              <span class="tag">Performance</span>
+              <h3>Performance Engineering</h3>
+              <p>Improved throughput and responsiveness for high-traffic digital platforms.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="contact glass" id="contact">
+          <h2>Elsewhere</h2>
+          <p>Read long-form thoughts on engineering and product.</p>
+          <a class="btn" href="https://medium.com/@theodor.chichirita" target="_blank" rel="noopener">Blog</a>
+          <p class="note">Share your latest CV details and I can add a full timeline section next.</p>
+        </section>
+      </main>
+
+      <footer>
+        <p>© <span id="year"></span> Theodor Chichirita</p>
+      </footer>
+    </div>
+
+    <script src="main.js"></script>
+  </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,6 @@
+(function () {
+  var year = document.getElementById('year');
+  if (year) {
+    year.textContent = String(new Date().getFullYear());
+  }
+})();

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,6 +1,220 @@
-/* You can add global styles to this file, and also import other style files */
+:root {
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
 body {
-    /* display: block; */
-    background-color: black;
-    color: green;
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  color: #101114;
+  background:
+    radial-gradient(1200px 500px at 15% -10%, #dbe8ff 0%, #f6f8fb00 60%),
+    radial-gradient(900px 400px at 100% 0%, #f2f4fa 0%, #f6f8fb00 65%),
+    linear-gradient(180deg, #f6f8fb 0%, #eef2f8 100%);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.shell {
+  min-height: 100vh;
+  max-width: 1060px;
+  margin: 0 auto;
+  padding: 1.25rem;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.2rem;
+}
+
+.logo {
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: #101114;
+  text-decoration: none;
+}
+
+nav {
+  display: flex;
+  gap: 1rem;
+}
+
+nav a {
+  color: #4f566b;
+  text-decoration: none;
+  font-size: 0.92rem;
+  font-weight: 500;
+}
+
+main {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.glass {
+  background: #ffffffc2;
+  border: 1px solid #ffffff;
+  border-radius: 22px;
+  box-shadow: 0 10px 35px #6f85ab21;
+  backdrop-filter: blur(14px);
+}
+
+.hero,
+.about,
+.contact {
+  padding: 2rem;
+}
+
+.kicker {
+  margin: 0;
+  color: #6a7186;
+  font-size: 0.84rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0.4rem 0;
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 1.08;
+  letter-spacing: -0.03em;
+}
+
+.role {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #31374a;
+  font-weight: 600;
+}
+
+.location {
+  margin-top: 0.8rem;
+  color: #5d657d;
+  max-width: 62ch;
+  line-height: 1.6;
+}
+
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-top: 1.3rem;
+}
+
+.btn {
+  border: 1px solid #d5daea;
+  color: #151924;
+  text-decoration: none;
+  border-radius: 999px;
+  padding: 0.57rem 1rem;
+  font-size: 0.92rem;
+  font-weight: 600;
+  background: #fff;
+  width: fit-content;
+}
+
+.btn-primary {
+  border: 1px solid #1f232f;
+  background: #1f232f;
+  color: #fff;
+}
+
+h2 {
+  margin-top: 0;
+  margin-bottom: 0.6rem;
+  font-size: 1.35rem;
+  letter-spacing: -0.01em;
+}
+
+ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: #434a5d;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.work {
+  padding: 0.2rem;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.card {
+  padding: 1.25rem;
+}
+
+.tag {
+  display: inline-block;
+  font-size: 0.75rem;
+  color: #6a7186;
+  background: #eef2f8;
+  border-radius: 999px;
+  padding: 0.18rem 0.52rem;
+  margin-bottom: 0.6rem;
+}
+
+h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.05rem;
+  letter-spacing: -0.01em;
+}
+
+.card p,
+.contact p,
+.note {
+  margin: 0;
+  color: #515973;
+  line-height: 1.52;
+}
+
+.contact {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.note {
+  font-size: 0.9rem;
+}
+
+footer {
+  text-align: center;
+  color: #6a7186;
+  font-size: 0.85rem;
+  margin: 1.4rem 0 0.5rem;
+}
+
+@media (max-width: 920px) {
+  .cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .shell {
+    padding: 0.8rem;
+  }
+
+  .hero,
+  .about,
+  .contact {
+    padding: 1.2rem;
+  }
+
+  nav {
+    gap: 0.7rem;
+  }
 }


### PR DESCRIPTION
### Motivation
- Replace the previous Angular CLI demo/terminal UI with a lightweight static personal landing page and simplify project tooling for easy hosting.
- Modernize the UI to a clean responsive landing layout that highlights name, role, highlights, projects and external links.

### Description
- Replace `package.json` with a simplified manifest (`version` bumped to `2.0.0`) and add `start`, `build`, and `test` scripts that serve and package the static `src/` site.
- Rewrite the application to a static-focused structure by simplifying `src/app/app.component.ts` to expose profile data and lists, and replace the old interactive terminal UI with a semantic `app.component.html` layout.
- Fully restyle the site by replacing the old component CSS and consolidating global styling in `src/styles.css`, and add `src/main.js` to populate the footer year.
- Replace `src/index.html` with a full static entry document and update `src/app/app.component.spec.ts` tests to assert the updated profile values and rendered headline.

### Testing
- Ran `npm test`, which invokes the configured test script and exited successfully while printing a notice that no automated tests are configured for the static site.
- Updated unit tests in `src/app/app.component.spec.ts` to match the refactored component and code style changes; the test file was adjusted to new expectations but the Angular test runner (`ng test`) is no longer configured and was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3f4ae3410832e9beb80dafc72f7f1)